### PR TITLE
Add an optional property to specify the number of partitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ and use below properties. ( See Java and Scala Code example on how to use these 
 	* zookeeper.consumer.path=/spark-kafka
 * Kafka Consumer ID. This ID will be used for accessing offset details in $zookeeper.consumer.path
 	* kafka.consumer.id=12345
+* Number of partitions for the topic. Optional. Only required if ZK is not reachable from the driver.
+	* kafka.partitions.number=100
 
 
 Java Example

--- a/examples/scala/LowLevelKafkaConsumer.scala
+++ b/examples/scala/LowLevelKafkaConsumer.scala
@@ -41,6 +41,8 @@ object LowLevelKafkaConsumer {
 	//It should be less than or equal to number of Partitions of your topic
     val numberOfReceivers = 1
 
+	//The number of partitions for the topic will be figured out automatically
+	//However, it can be manually specified by adding kafka.partitions.number property
     val kafkaProperties: Map[String, String] = Map("zookeeper.hosts" -> zkhosts,
                                                    "zookeeper.port" -> zkports,
                                                    "zookeeper.broker.path" -> brokerPath ,

--- a/src/main/java/consumer/kafka/Config.java
+++ b/src/main/java/consumer/kafka/Config.java
@@ -35,6 +35,7 @@ public class Config extends HashMap<String, Object> implements Serializable {
 	public static final String ZOOKEEPER_HOSTS = "zookeeper.hosts";
 	public static final String ZOOKEEPER_PORT = "zookeeper.port";
 	public static final String KAFKA_TOPIC = "kafka.topic";
+	public static final String KAFKA_PARTITIONS_NUMBER = "kafka.partitions.number";
 	public static final String ZOOKEEPER_BROKER_PATH = "zookeeper.broker.path";
 
 	/**

--- a/src/main/java/consumer/kafka/ReceiverLauncher.java
+++ b/src/main/java/consumer/kafka/ReceiverLauncher.java
@@ -39,15 +39,19 @@ public class ReceiverLauncher implements Serializable{
 		
 		List<JavaDStream<MessageAndMetadata>> streamsList = new ArrayList<JavaDStream<MessageAndMetadata>>();
 		JavaDStream<MessageAndMetadata> unionStreams;
+		int numberOfPartition;
+		String numberOfPartitionStr = (String) pros.getProperty(Config.KAFKA_PARTITIONS_NUMBER);
+		if (numberOfPartitionStr != null) {
+			numberOfPartition = Integer.parseInt(numberOfPartitionStr);
+		} else {
+			KafkaConfig kafkaConfig = new KafkaConfig(pros);
+			ZkState zkState = new ZkState(kafkaConfig);
 		
-		KafkaConfig kafkaConfig = new KafkaConfig(pros);
-		ZkState zkState = new ZkState(kafkaConfig);
-		
-		_zkPath = (String) kafkaConfig._stateConf.get(Config.ZOOKEEPER_BROKER_PATH);
-		_topic = (String) kafkaConfig._stateConf.get(Config.KAFKA_TOPIC);
-		
-		int numberOfPartition = getNumPartitions(zkState);
-		
+			_zkPath = (String) kafkaConfig._stateConf.get(Config.ZOOKEEPER_BROKER_PATH);
+			_topic = (String) kafkaConfig._stateConf.get(Config.KAFKA_TOPIC);
+			numberOfPartition = getNumPartitions(zkState);
+		}
+
 		//Create as many Receiver as Partition
 		if(numberOfReceivers >= numberOfPartition) {
 			

--- a/src/main/java/consumer/kafka/client/Consumer.java
+++ b/src/main/java/consumer/kafka/client/Consumer.java
@@ -53,6 +53,9 @@ public class Consumer implements Serializable {
 		props.put("kafka.consumer.id", "valid_subpub");		
 		props.put("zookeeper.consumer.connection", "10.252.5.113:2182");
 		props.put("zookeeper.consumer.path", "/kafka-new");
+		//The number of partitions for the topic will be figured out automatically
+		//However, it can be manually specified by adding kafka.partitions.number property
+		//props.put("kafka.partitions.number", "100");
 		
 		SparkConf _sparkConf = new SparkConf().setAppName("KafkaReceiver")
 				.set("spark.streaming.receiver.writeAheadLog.enable", "false");;


### PR DESCRIPTION
This adds a new, optional, property named `kafka.partitions.number` in order to specify the number of partitions for the given topic.

Automatic detection of the number of partitions is great, but is not an option when the driver is not allowed to connect to the Zookeeper servers.

The previous behavior remains unchanged when this property is not given.
